### PR TITLE
Disable ApcuCache for Doctrine

### DIFF
--- a/app/config/ext/nettrine.neon
+++ b/app/config/ext/nettrine.neon
@@ -44,7 +44,7 @@ nettrine.orm.annotations:
 nettrine.orm.cache:
 
 nettrine.cache:
-	driver: Doctrine\Common\Cache\ApcuCache
+#	driver: Doctrine\Common\Cache\ApcuCache
 
 nettrine.migrations:
 	table: doctrine_migrations


### PR DESCRIPTION
It is better to disable it by default (as in [contributte/webapp-skeleton](https://github.com/contributte/webapp-skeleton/blob/master/app/config/ext/nettrine.neon)). It took me a while to figure it out where Doctrine has old entity mapping information.