### PR TITLE
fix: don't flush users in every iteration

### DIFF
--- a/db/Fixtures/UserFixture.php
+++ b/db/Fixtures/UserFixture.php
@@ -28,8 +28,9 @@ class UserFixture extends AbstractFixture
 
 		foreach ($this->getRandomUsers() as $user) {
 			$this->manager->persist($user);
-			$this->manager->flush();
 		}
+		
+		$this->manager->flush();
 	}
 
 	/**
@@ -82,7 +83,6 @@ class UserFixture extends AbstractFixture
 		$entity->setApikey($user['apikey']);
 
 		$this->manager->persist($entity);
-		$this->manager->flush();
 	}
 
 }


### PR DESCRIPTION
Calling the flush() only once so all random users are flushed in one transaction.