### PR TITLE
Config: Remove hardcoded server version

### DIFF
--- a/config/ext/nettrine.neon
+++ b/config/ext/nettrine.neon
@@ -30,7 +30,7 @@ nettrine.dbal:
 		password: %database.password%
 		dbname: %database.dbname%
 		port: %database.port%
-		serverVersion: 12
+		serverVersion: %database.serverVersion%
 
 nettrine.orm:
 	entityManagerDecoratorClass: App\Model\Database\EntityManagerDecorator

--- a/config/local.neon.example
+++ b/config/local.neon.example
@@ -9,6 +9,7 @@ parameters:
 		dbname: contributte
 		user: contributte
 		password: contributte
+		serverVersion: null
 
 	# Database (mariadb)
 	# database:
@@ -18,3 +19,4 @@ parameters:
 	# 	dbname: contributte
 	# 	user: contributte
 	# 	password: contributte
+	#	serverVersion: null


### PR DESCRIPTION
I was debugging an issue with `doctrine-migrations` not working on a project using the `apitte-skeleton` with `MariaDB`. After a while I have noticed that the `serverVersion` was hardcoded which was causing the problem. IMO it should not be hardcoded or it should at least be editable in the `local.neon` file, so that the configuration is in one place. 