### PR TITLE
Snake case name convertor missmatch with openapi

### DIFF
--- a/config/app/services.neon
+++ b/config/app/services.neon
@@ -18,7 +18,6 @@ services:
 	symfony.serializer.objectNormalizer:
 		factory: Symfony\Component\Serializer\Normalizer\ObjectNormalizer(
 			classMetadataFactory: @symfony.serializer.classMetadataFactory,
-			nameConverter: Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter(),
 			propertyAccessor: null,
 			propertyTypeExtractor: Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor()
 		)


### PR DESCRIPTION
Using nameConvertor to snake case is leading to missmatch with open api.

If you have good annotations f.e. property $fullName in response DTO openapi will generate { fullName: "string" } but reality with nameConvertor is { full_name: "John Doe" }. So there should be fix on side of openapi or removing nameConvertor