### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.4"
       make: "init coverage"


### PR DESCRIPTION
## What changed
- added `secrets: inherit` to `.github/workflows/coverage.yml` when calling the reusable coverage workflow

## Why
- lets the reusable coverage workflow receive required secrets during the contributte/contributte#74 rollout for this repository