### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.4"
       make: "init coverage"


### PR DESCRIPTION
## What changed
- switched the coverage workflow to the shared `nette-tester-coverage-v2` reusable workflow
- added `secrets: inherit` so the coverage job can access required repository secrets

## Why
- the updated shared coverage workflow requires inherited secrets to keep coverage reporting working for forks and repository CI

contributte/contributte#74